### PR TITLE
redisのdumpファイルをignoreする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,8 @@
 
 /public/assets
 
+# redis
+redis/data/*
+
 # Ignore master key for decrypting credentials and more.
 /config/master.key


### PR DESCRIPTION
Close #xxxx

## 実装の概要
`redis/data/dump.rdb`ファイルがgit で追跡されないようにする

## スクリーンショット

## 参考URL

## テスト項目
- [ ] test
- [ ] test
