### PR TITLE
harry porterの呪文apiをfaradayで叩く

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,9 @@ gem 'slim-rails'
 
 gem "seed-fu"
 
+# HTTPクライアント機能
+gem "faraday"
+
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,11 @@ GEM
     erubi (1.13.0)
     et-orbi (1.2.11)
       tzinfo
+    faraday (2.10.0)
+      faraday-net_http (>= 2.0, < 3.2)
+      logger
+    faraday-net_http (3.1.0)
+      net-http
     fugit (1.11.0)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -147,6 +152,8 @@ GEM
     minitest (5.24.1)
     msgpack (1.7.2)
     mutex_m (0.2.0)
+    net-http (0.4.1)
+      uri
     net-imap (0.4.14)
       date
       net-protocol
@@ -297,6 +304,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
+    uri (0.13.0)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -319,6 +327,7 @@ DEPENDENCIES
   capybara
   debug
   dotenv-rails
+  faraday
   importmap-rails
   jbuilder
   line-bot-api

--- a/app/controllers/hp_apis_controller.rb
+++ b/app/controllers/hp_apis_controller.rb
@@ -1,0 +1,6 @@
+class HpApisController < ApplicationController
+  def index
+    response = Faraday.get('https://hp-api.onrender.com/api/spells')
+    render json: { response: response.body }
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,8 @@ module DockerPractice
     config.generators do |g|
       g.assets false
       g.helper false
+      g.skip_routes false
+      g.test_framework false
     end
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'hp_apis/index'
   require 'sidekiq/web'
   require 'sidekiq-scheduler/web'
 
@@ -6,8 +7,9 @@ Rails.application.routes.draw do
     [user_id, password] == [ENV['USER_ID'], ENV['USER_PASSWORD']]
   end
   mount Sidekiq::Web, at: '/sidekiq'
-  
+
   resources :users, only: %i[new create]
+  get '/hp_apis', to: 'hp_apis#index'
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-  get 'hp_apis/index'
   require 'sidekiq/web'
   require 'sidekiq-scheduler/web'
 


### PR DESCRIPTION
Close #7 

## 実装の概要
`faraday`を使用して、harrypotterのapiを叩いて、レスポンスが返される
`rails g`コマンドで自動生成でルーティング・テストファイルが作成されるのをスキップ
## スクリーンショット
<img width="1304" alt="2f180d233833e5780f657a3cd3dc55e7" src="https://github.com/isakashiori/docker_practice_rails7/assets/101505652/53f627a6-4e0a-4b8e-90f8-720d07037e32">


## 参考URL

## テスト項目
- [x] 全ての呪文がレスポンスとして返ってくることをpostmanで確認
