### PR TITLE
Faradayでopenai APIを叩く

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+
+#sidekiqデスクトップ管理画面へのログイン情報
+USER_ID=
+USER_PASSWORD=
+
+#line
+LINE_CHANNEL_SECRET=
+LINE_CHANNEL_TOKEN=
+LINE_USER_ID=
+
+# openAI 
+OPENAI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 /.bundle
 
 # Ignore all environment files (except templates).
-/.env*
+/.env
 !/.env*.erb
 
 # Ignore all logfiles and tempfiles.

--- a/app/controllers/gpt_reply_messages_controller.rb
+++ b/app/controllers/gpt_reply_messages_controller.rb
@@ -1,0 +1,7 @@
+class GptReplyMessagesController < ApplicationController
+  def create
+    # faradayでapiを叩くコードが長くなるため、servicesファイルに切り出す
+    response = GptReplyService.new(params[:ask_msg]).perform
+    render json: { response: response }
+  end
+end

--- a/app/controllers/gpt_reply_messages_controller.rb
+++ b/app/controllers/gpt_reply_messages_controller.rb
@@ -1,4 +1,4 @@
-class GptReplyMessagesController < ApplicationController
+class GptReplyMessagesController < ActionController::API
   def create
     # faradayでapiを叩くコードが長くなるため、servicesファイルに切り出す
     response = GptReplyService.new(params[:ask_msg]).perform

--- a/app/services/gpt_reply_service.rb
+++ b/app/services/gpt_reply_service.rb
@@ -1,5 +1,9 @@
-class GetReplyService
-  def perform(ask_msg)
+class GptReplyService
+  def initialize(ask_msg)
+    @ask_msg = ask_msg
+  end
+
+  def perform
     # 一旦エンドポイントは以下しか使わない予定で書いている
     # より汎用的に書くのであればFaraday.newでコネクションのインスタンスを作成した方がいい
     response = Faraday.post("https://api.openai.com/v1/chat/completions") do |req|
@@ -7,7 +11,7 @@ class GetReplyService
       req.headers["Authorization"] = "Bearer #{ENV['OPENAI_API_KEY']}"
       req.body = {
                     model: "gpt-3.5-turbo",
-                    messages: [{role: "user", content: ask_msg}],
+                    messages: [{role: "user", content: @ask_msg}],
                     temperature: 0.7
                   }.to_json
     end

--- a/app/services/gpt_reply_service.rb
+++ b/app/services/gpt_reply_service.rb
@@ -1,19 +1,20 @@
 class GptReplyService
   def initialize(ask_msg)
     @ask_msg = ask_msg
+    @response = Faraday.new("https://api.openai.com") do |req|
+      req.headers["Content-Type"] = "application/json"
+      req.headers["Authorization"] = "Bearer #{ENV['OPENAI_API_KEY']}"
+      req.adapter Faraday.default_adapter
+    end
   end
 
   def perform
-    # 一旦エンドポイントは以下しか使わない予定で書いている
-    # より汎用的に書くのであればFaraday.newでコネクションのインスタンスを作成した方がいい
-    response = Faraday.post("https://api.openai.com/v1/chat/completions") do |req|
-      req.headers["Content-Type"] = "application/json"
-      req.headers["Authorization"] = "Bearer #{ENV['OPENAI_API_KEY']}"
-      req.body = {
-                    model: "gpt-3.5-turbo",
-                    messages: [{role: "user", content: @ask_msg}],
-                    temperature: 0.7
-                  }.to_json
+    response = @response.post("/v1/chat/completions") do |conn|
+      conn.body = {
+        model: "gpt-3.5-turbo",
+        messages: [{role: "user", content: @ask_msg}],
+        temperature: 0.7
+      }.to_json
     end
   end
 end

--- a/app/services/gpt_reply_service.rb
+++ b/app/services/gpt_reply_service.rb
@@ -1,0 +1,15 @@
+class GetReplyService
+  def perform(ask_msg)
+    # 一旦エンドポイントは以下しか使わない予定で書いている
+    # より汎用的に書くのであればFaraday.newでコネクションのインスタンスを作成した方がいい
+    response = Faraday.post("https://api.openai.com/v1/chat/completions") do |req|
+      req.headers["Content-Type"] = "application/json"
+      req.headers["Authorization"] = "Bearer #{ENV['OPENAI_API_KEY']}"
+      req.body = {
+                    model: "gpt-3.5-turbo",
+                    messages: [{role: "user", content: ask_msg}],
+                    temperature: 0.7
+                  }.to_json
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
 
   resources :users, only: %i[new create]
   get '/hp_apis', to: 'hp_apis#index'
+  post '/gpt_reply', to: 'gpt_reply_messages#create'
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.


### PR DESCRIPTION
Close #28 

## 実装の概要
現状`You exceeded your current quota, please check your plan and billing details`のエラーで止まっている
## スクリーンショット

## 参考URL


## メモ
curlコマンドからでもpostmanからpostリクエストを送っても一向に`442 Action Controller: Exception caught`の表示で
正常にレスポンスが帰ってこないため、`development.log`を確認すると下記のようなエラーが表示されていた

```
Started POST "/gpt_reply" for 127.0.0.1 at 2024-07-15 11:17:53 +0000
  [1m[36mActiveRecord::SchemaMigration Load (5.3ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
Processing by GptReplyMessagesController#create as */*
  Parameters: {"ask_msg"=>"快眠できる方法を教えてください", "gpt_reply_message"=>{"ask_msg"=>"快眠できる方法を教えてください"}}
Can't verify CSRF token authenticity.
Completed 422 Unprocessable Content in 5ms (ActiveRecord: 0.0ms | Allocations: 585)


  
ActionController::InvalidAuthenticityToken (Can't verify CSRF token authenticity.):
```
これはapiモードでrails newをしていないため、外部クライアント(openaiのこと)からのリクエストをrails側が許可していないため
そのためCSRF保護を無効にしてあげる必要がある。
https://qiita.com/nishina555/items/4ffaf5cc57a384b66230

## テスト項目
- [ ] test
- [ ] test
