### PR TITLE
docker上ではtailwindcss:watchが効かないためtailwindのコンテナを作成

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,13 +18,13 @@ services:
     depends_on:
       - db
     tty: true
-  # tailwind:
-  #   build: 
-  #     <<: *web_build
-  #   command: bin/rails tailwindcss:watch
-  #   tty: true
-  #   volumes:
-  #     - .:/docker_practice
+  tailwind:
+    build:
+      <<: *web_build
+    command: bin/rails tailwindcss:watch
+    tty: true
+    volumes:
+      - .:/docker_practice
   redis:
     image: "redis:latest"
     ports:


### PR DESCRIPTION
Close #xxxx

## 実装の概要
表題通り

`rails tailwind:build`をせずとも変更が反映されるように`docker-compose`ファイル内に
`tailwind`のコンテナを作成してそこで`tailwindcss:wacth`するように変更した

## テスト項目
- [x] tailwindのクラスを変更するとリロードしてすぐに変更が反映されることを確認
