### PR TITLE
LINE通知が定期実行されない問題を解消

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,2 @@
 css: bin/rails tailwindcss:watch
-redis: docker-compose up redis
-sidekiq: docker-compose up sidekiq
+


### PR DESCRIPTION
Close #43 

## 実装の概要
表題の件を解消
原因はprocfile.devにsidekiq、ledisのコンテナを起動するコードがあったため、
これを削除すると通知が正常に定期実行された

具体的にな原因についてもっと深掘りすること

## スクリーンショット
なし

## 参考URL
なし

## テスト項目
- [ ] test
- [ ] test
